### PR TITLE
Added ability to render from input.js

### DIFF
--- a/acf-code-field-v5.php
+++ b/acf-code-field-v5.php
@@ -172,17 +172,6 @@ class acf_code_field extends acf_field {
 		wp_enqueue_style( 'codemirror-curr-style', "{$dir}js/codemirror-5.13/theme/{$field['theme']}.css" );
 
 		?>
-
-		<script>
-			var code_field_<?php echo $safe_slug; ?> = document.getElementById('<?php echo $field[ 'id' ]; ?>');
-			var editor = CodeMirror.fromTextArea(code_field_<?php echo $safe_slug; ?>, {
-				lineNumbers: true,
-				mode       : '<?php echo esc_js($field[ 'mode' ]); ?>',
-				theme      : '<?php echo $field['theme']; ?>',
-				extraKeys  : {"Ctrl-Space": "autocomplete"},
-				value      : document.documentElement.innerHTML
-			});
-		</script>
 		<?php
 	}
 
@@ -210,6 +199,7 @@ class acf_code_field extends acf_field {
 		$dir = plugin_dir_url( __FILE__ );
 
 		// register & include JS
+		wp_enqueue_script( 'acf-input-code-field', "{$dir}js/input.js" );
 		wp_enqueue_script( 'acf-input-code-field-codemirror', "{$dir}js/codemirror-5.13/lib/codemirror.js" );
 		wp_enqueue_script( 'acf-input-code-field-codemirror-css', "{$dir}js/codemirror-5.13/mode/css/css.js" );
 		wp_enqueue_script( 'acf-input-code-field-codemirror-js', "{$dir}js/codemirror-5.13/mode/javascript/javascript.js" );

--- a/js/input.js
+++ b/js/input.js
@@ -1,15 +1,30 @@
 (function($){
-	
-	
-	function initialize_field( $el ) {
-		
-		//$el.doStuff();
-		
-	}
-	
-	
 	if( typeof acf.add_action !== 'undefined' ) {
-	
+
+		function initialize_code_field($el){
+			//if just a clone element for repeater field
+			if($el.parents(".acf-clone").length >0)
+				return;
+
+			var $textarea = $el.find('.acf-input>textarea');
+
+			//load needed CSS if doesn't already exist
+			if (!$("link[href='/wp-content/plugins/acf-code-field/js/codemirror-5.13/theme/"+  $textarea.attr("theme") +".css']").length)
+				$('<link href="/wp-content/plugins/acf-code-field/js/codemirror-5.13/theme/'+  $textarea.attr("theme") + '.css" rel="stylesheet">').appendTo("head");
+
+			var editor = CodeMirror.fromTextArea($textarea[0], {
+				lineNumbers: true,
+				fixedGutter: false,
+				mode       : $textarea.attr("mode"),
+				theme      : $textarea.attr("theme"),
+				extraKeys  : {"Ctrl-Space": "autocomplete"},
+				value      : document.documentElement.innerHTML
+			});
+			editor.refresh();
+
+			console.log("Added new code field")
+		}
+
 		/*
 		*  ready append (ACF5)
 		*
@@ -23,48 +38,18 @@
 		*  @param	$el (jQuery selection) the jQuery element which contains the ACF fields
 		*  @return	n/a
 		*/
-		
-		acf.add_action('ready append', function( $el ){
-			
-			// search $el for fields of type 'FIELD_NAME'
-			acf.get_fields({ type : 'FIELD_NAME'}, $el).each(function(){
-				
-				initialize_field( $(this) );
-				
+
+		acf.add_action('ready', function( $el ){
+			$el.find(".acf-field-acf-code-field").each(function(index, field){
+				initialize_code_field($(field));
 			});
-			
+
 		});
-		
-		
-	} else {
-		
-		
-		/*
-		*  acf/setup_fields (ACF4)
-		*
-		*  This event is triggered when ACF adds any new elements to the DOM. 
-		*
-		*  @type	function
-		*  @since	1.0.0
-		*  @date	01/01/12
-		*
-		*  @param	event		e: an event object. This can be ignored
-		*  @param	Element		postbox: An element which contains the new HTML
-		*
-		*  @return	n/a
-		*/
-		
-		$(document).on('acf/setup_fields', function(e, postbox){
-			
-			$(postbox).find('.field[data-field_type="FIELD_NAME"]').each(function(){
-				
-				initialize_field( $(this) );
-				
-			});
-		
+		acf.add_action('append_field', function( $el ){
+			if($el.attr('data-type') == "acf_code_field"){
+				initialize_code_field($el);
+			}
 		});
-	
-	
 	}
 
 


### PR DESCRIPTION
Removed <script> tag rending of codemirror on the field. CodeMirror is
now rendered from input.js and allows for proper
functionality with repeater/flexible content fields.